### PR TITLE
introducing system/local deployment

### DIFF
--- a/README/spec/ansible.spec
+++ b/README/spec/ansible.spec
@@ -1,0 +1,11 @@
+#############################################################
+#
+# Possible values for group_vars/all/ansible
+# 
+############################################################
+
+ansible_conf:
+  host: <THE-ANSIBLE-SERVER-NAME | FQDN>
+  * Set a name to identify this ansible instance. It will be used in several places e.g. in 
+    the deploy_systemconfigs playbook
+

--- a/README/spec/system_local_configs.spec
+++ b/README/spec/system_local_configs.spec
@@ -1,0 +1,15 @@
+###################################################################
+#
+# Possible values for group_vars/<targetgroup>/system_local_configs
+# 
+###################################################################
+
+system_local_configs:
+  system:
+    remove_absent_files: [True | False]
+    * Dangerous setting. This removes unmanaged files on the remote host. 
+      unmanaged means: missing Ansible header at the top of the file.
+      When you run the system local deployment a header will be placed at the top
+      of each file automatically but for those files created in the meantime manually
+      <remove_absent_files: True> will remove those manually created ones.
+      Default is False.

--- a/deploy_systemconfigs.yml
+++ b/deploy_systemconfigs.yml
@@ -1,0 +1,9 @@
+- name: Deploy System Configs
+  hosts: "{{ exp_host }}"
+  user: splunk
+
+  pre_tasks:
+    - include_vars: group_vars/all/ansible
+
+  roles:
+    - system/{{ target }}/{{ exp_host }}/system_local_configs

--- a/roles/system/template/system_local_configs/files/README
+++ b/roles/system/template/system_local_configs/files/README
@@ -1,0 +1,1 @@
+Placeholder

--- a/roles/system/template/system_local_configs/files/system/local/00_ANSIBLE_FILEMANAGED.conf
+++ b/roles/system/template/system_local_configs/files/system/local/00_ANSIBLE_FILEMANAGED.conf
@@ -1,0 +1,1 @@
+########## ANSIBLE FILE-MANAGED - DO NOT TOUCH WITHOUT ANSIBLE  ##########

--- a/roles/system/template/system_local_configs/files/system/local/README
+++ b/roles/system/template/system_local_configs/files/system/local/README
@@ -1,0 +1,32 @@
+#####################################################################################
+#
+# Place all files you want to push inside this directory
+# - they will be pushed 1:1 so they have to have .conf ending 
+#   so splunk recognizes them
+#
+#
+# Hint:
+# Whenever you deploy ansible managed files from the ansible server to a target
+# a phrase will be added to the top of each conf file:
+#
+# ########## ANSIBLE FILE-MANAGED - DO NOT TOUCH WITHOUT ANSIBLE (some info) ##########
+#
+# If using now or later the "remove_absent_files" feature ansible will check 
+# for this exact phrase to find out which files are managed and which not!
+# 
+# remove_absent_files - feature:
+#     When you set the "remove_absent_files = true" in the config file all files without
+#     the above phrase will be RENAMED (to $file-unmanaged).
+#     Exact phrase = "^#+\sAnSiBLe\sFiLE-MANaGeD"
+# 	- whole phrase is case insensitive (e.g.: ansible or ANSIBLE or AnSIbLE will all match)
+# 	- "^#+" => search for "#" at the beginning of a line
+# 	- "\s" 	=> 1 white space (no TAB! and not more then 1)
+# 	- the full file! will be checked for this phrase (no need to have it on top but its recommended)
+#
+# Changes made in the GUI:
+#     When you have made changes within the GUI you have to ensure that you
+#     copy the changed files to your ansible server and place them in the 
+#     corresponded directory. If you forget to copy them over and you run ansible the
+#     next time they get overwritten!
+#
+#####################################################################################

--- a/roles/system/template/system_local_configs/files/system/local/zz_ANSIBLE_FILEMANAGED.conf
+++ b/roles/system/template/system_local_configs/files/system/local/zz_ANSIBLE_FILEMANAGED.conf
@@ -1,0 +1,1 @@
+########## ANSIBLE FILE-MANAGED - DO NOT TOUCH WITHOUT ANSIBLE  ##########

--- a/roles/system/template/system_local_configs/tasks/configure_local.yml
+++ b/roles/system/template/system_local_configs/tasks/configure_local.yml
@@ -1,0 +1,16 @@
+---
+# THIS GETS OVERWRITTEN EACH RUN FROM: roles/system/template/ DIRECTORY! 
+- name: clear var
+  set_fact: shouldinstall="False"
+
+- name: set the var according to the users setting
+  set_fact: shouldinstall="{{ item.value.install }}"
+  when: item.key == "system"
+  with_dict: "{{ vars['app_variable'] }} |app_default"
+
+- name: Configure SYSTEM (local/*.conf)
+  copy: src="{{ item }}"
+        dest="{{ splunk_installation.splunk_home_path }}/etc/system/local/"
+  when: shouldinstall == true
+  with_fileglob: system/local/*.conf
+

--- a/roles/system/template/system_local_configs/tasks/inject_myfiles.yml
+++ b/roles/system/template/system_local_configs/tasks/inject_myfiles.yml
@@ -1,0 +1,18 @@
+---
+# THIS GETS OVERWRITTEN EACH RUN FROM: roles/system/template/ DIRECTORY! 
+- name: set the var according to the users setting
+  set_fact: shouldinstall="{{ item.value.install }}"
+  when: item.key == "system"
+  with_dict: "{{ vars['app_variable'] }} |app_default"
+
+- name: Prepare local files (local/*.conf)
+  local_action: 
+        module: lineinfile
+        dest: "{{ item }}" 
+        regexp: "^#+ ANSIBLE FILE-MANAGED - DO NOT TOUCH WITHOUT ANSIBLE.*"
+        state: present
+        line: "########## ANSIBLE FILE-MANAGED - DO NOT TOUCH WITHOUT ANSIBLE (last run initiated from: {{ ansible_conf.host }}) ##########\n"
+        insertbefore: BOF
+  with_fileglob: system/local/*.conf
+
+

--- a/roles/system/template/system_local_configs/tasks/main.yml
+++ b/roles/system/template/system_local_configs/tasks/main.yml
@@ -1,0 +1,7 @@
+---
+# THIS GETS OVERWRITTEN EACH RUN FROM: roles/system/template/ DIRECTORY! 
+- include: ../../../../../common/handlers/splunkd.yml
+- include: inject_myfiles.yml
+- include: configure_local.yml
+- include: remove_conf_files.yml
+- include: push_conf.yml

--- a/roles/system/template/system_local_configs/tasks/push_conf.yml
+++ b/roles/system/template/system_local_configs/tasks/push_conf.yml
@@ -1,0 +1,8 @@
+---
+# THIS GETS OVERWRITTEN EACH RUN FROM: roles/system/template/ DIRECTORY! 
+
+- name: Copy conf to remote host
+  copy: src="{{ item }}"
+        dest="/{{ splunk_conf_path }}/"
+  with_fileglob: system/local/*.conf
+

--- a/roles/system/template/system_local_configs/tasks/remove_conf_files.yml
+++ b/roles/system/template/system_local_configs/tasks/remove_conf_files.yml
@@ -1,0 +1,21 @@
+---
+# THIS GETS OVERWRITTEN EACH RUN FROM: roles/system/template/ DIRECTORY! 
+- name: Prepare the next tasks
+  set_fact: handle_unmanaged=false
+
+- name: Check what to do with unmanaged configs
+  set_fact: handle_unmanaged=true
+  when: "{{ item.value.remove_absent_files }} is defined and
+        {{ item.value.remove_absent_files }} == true"
+  with_dict: "{{ vars['app_variable'] }} | app_default"
+
+- name: Get all unmanaged config files
+  shell: grep -Li '^# ANSIBLE FILE-MANAGED' {{ splunk_installation.splunk_home_path }}/etc/system/local/*.conf || true
+  register: grep_unmanaged
+  changed_when: false
+
+- name: Add '-unmanaged' suffix to all unmanaged files
+  shell: mv {{ item }} {{ item }}-unmanaged
+  with_items: grep_unmanaged.stdout_lines
+  when: handle_unmanaged
+

--- a/roles/system/template/system_local_configs/vars/main.yml
+++ b/roles/system/template/system_local_configs/vars/main.yml
@@ -1,0 +1,5 @@
+---
+# Change to app name
+app_name: system_local_configs 
+# Change to app variable name. Must not contain dashes (-). Must be the same variable as defined in group_vars for app. This is due to variable name restrictions.
+app_variable: system_local_configs

--- a/roles/system/template/system_local_configs/vars/main.yml.j2
+++ b/roles/system/template/system_local_configs/vars/main.yml.j2
@@ -1,0 +1,3 @@
+---
+app_name: {{ app_name }}
+app_variable: {{ app_variable }}


### PR DESCRIPTION
allows to deploy any splunk config file for system/local without the INI module